### PR TITLE
Use build profile to enable RTEMS cross build

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,12 @@
-motor (6.9-1) UNRELEASED; urgency=medium
+motor (6.9-1) unstable; urgency=medium
 
+  [ mdavidsaver ]
   * initial
+
+  [ Michael Davidsaver ]
+  * missing rtems deps
+
+  [ Martin Konrad ]
+  * Use build profile to enable RTEMS cross build
 
  --  mdavidsaver <mdavidsaver@gmail.com>  Thu, 10 Mar 2016 14:44:39 -0500

--- a/debian/control
+++ b/debian/control
@@ -2,27 +2,27 @@ Source: motor
 Section: libdevel
 Priority: extra
 Maintainer: mdavidsaver <mdavidsaver@gmail.com>
-Build-Depends: debhelper (>= 9), epics-debhelper (>= 8.14~),
-               epics-dev,
-               rtems-epics-mvme2100,
-               rtems-epics-mvme3100,
-               rtems-epics-mvme5500,
-               rtems-epics-pc386,
+Build-Depends: debhelper (>= 9.20141010), dpkg-dev (>=1.17.14),
+               epics-debhelper (>= 8.14~), epics-dev,
+               rtems-epics-mvme2100 <pkg.epics-base.rtems>,
+               rtems-epics-mvme3100 <pkg.epics-base.rtems>,
+               rtems-epics-mvme5500 <pkg.epics-base.rtems>,
+               rtems-epics-pc386 <pkg.epics-base.rtems>,
                epics-asyn-dev,
-               rtems-asyn-mvme2100,
-               rtems-asyn-mvme3100,
-               rtems-asyn-mvme5500,
-               rtems-asyn-pc386,
+               rtems-asyn-mvme2100 <pkg.epics-base.rtems>,
+               rtems-asyn-mvme3100 <pkg.epics-base.rtems>,
+               rtems-asyn-mvme5500 <pkg.epics-base.rtems>,
+               rtems-asyn-pc386 <pkg.epics-base.rtems>,
                epics-busy-dev,
-               rtems-busy-mvme2100,
-               rtems-busy-mvme3100,
-               rtems-busy-mvme5500,
-               rtems-busy-pc386,
+               rtems-busy-mvme2100 <pkg.epics-base.rtems>,
+               rtems-busy-mvme3100 <pkg.epics-base.rtems>,
+               rtems-busy-mvme5500 <pkg.epics-base.rtems>,
+               rtems-busy-pc386 <pkg.epics-base.rtems>,
                epics-seq-dev,
-               rtems-seq-mvme2100,
-               rtems-seq-mvme3100,
-               rtems-seq-mvme5500,
-               rtems-seq-pc386,
+               rtems-seq-mvme2100 <pkg.epics-base.rtems>,
+               rtems-seq-mvme3100 <pkg.epics-base.rtems>,
+               rtems-seq-mvme5500 <pkg.epics-base.rtems>,
+               rtems-seq-pc386 <pkg.epics-base.rtems>,
 XS-Rtems-Build-Depends: rtems-epics, rtems-asyn, rtems-busy, rtems-seq,
 Standards-Version: 3.9.6
 Homepage: http://aps.anl.gov/bcda/synApps/motor/index.html
@@ -50,6 +50,7 @@ Description: Motor controller drivers
  This package contains runtime libraries
 
 Package: rtems-motor-mvme2100
+Build-Profiles: <pkg.epics-base.rtems>
 Architecture: all
 Depends: epics-motor-dev (>= ${source:Version}),
          epics-motor-dev (<< ${source:Version}.1~),
@@ -61,6 +62,7 @@ Description: Motor controller drivers
  This package contains support for the MVME2100 VME SBC
 
 Package: rtems-motor-mvme3100
+Build-Profiles: <pkg.epics-base.rtems>
 Architecture: all
 Depends: epics-motor-dev (>= ${source:Version}),
          epics-motor-dev (<< ${source:Version}.1~),
@@ -72,6 +74,7 @@ Description: Motor controller drivers
  This package contains support for the MVME3100 VME SBC
 
 Package: rtems-motor-mvme5500
+Build-Profiles: <pkg.epics-base.rtems>
 Architecture: all
 Depends: epics-motor-dev (>= ${source:Version}),
          epics-motor-dev (<< ${source:Version}.1~),
@@ -83,6 +86,7 @@ Description: Motor controller drivers
  This package contains support for the MVME5500 VME SBC
 
 Package: rtems-motor-pc386
+Build-Profiles: <pkg.epics-base.rtems>
 Architecture: all
 Depends: epics-motor-dev (>= ${source:Version}),
          epics-motor-dev (<< ${source:Version}.1~),

--- a/debian/source/lintian-overrides
+++ b/debian/source/lintian-overrides
@@ -1,0 +1,20 @@
+motor source: invalid-restriction-formula-in-build-profiles-field <pkg.epics-base.rtems> rtems-motor-mvme2100
+motor source: invalid-restriction-formula-in-build-profiles-field <pkg.epics-base.rtems> rtems-motor-mvme3100
+motor source: invalid-restriction-formula-in-build-profiles-field <pkg.epics-base.rtems> rtems-motor-mvme5500
+motor source: invalid-restriction-formula-in-build-profiles-field <pkg.epics-base.rtems> rtems-motor-pc386
+motor source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-epics-mvme2100 <pkg.epics-base.rtems>]
+motor source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-epics-mvme3100 <pkg.epics-base.rtems>]
+motor source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-epics-mvme5500 <pkg.epics-base.rtems>]
+motor source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-epics-pc386 <pkg.epics-base.rtems>]
+motor source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-asyn-mvme2100 <pkg.epics-base.rtems>]
+motor source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-asyn-mvme3100 <pkg.epics-base.rtems>]
+motor source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-asyn-mvme5500 <pkg.epics-base.rtems>]
+motor source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-asyn-pc386 <pkg.epics-base.rtems>]
+motor source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-busy-mvme2100 <pkg.epics-base.rtems>]
+motor source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-busy-mvme3100 <pkg.epics-base.rtems>]
+motor source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-busy-mvme5500 <pkg.epics-base.rtems>]
+motor source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-busy-pc386 <pkg.epics-base.rtems>]
+motor source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-seq-mvme2100 <pkg.epics-base.rtems>]
+motor source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-seq-mvme3100 <pkg.epics-base.rtems>]
+motor source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-seq-mvme5500 <pkg.epics-base.rtems>]
+motor source: invalid-profile-name-in-source-relation pkg.epics-base.rtems [build-depends: rtems-seq-pc386 <pkg.epics-base.rtems>]


### PR DESCRIPTION
This allows facilities that do not use RTEMS to get rid of the complexity of building this package's RTEMS dependencies. Set the environment variable `DEB_BUILD_PROFILES=pkg.epics-base.rtems` when compiling to enable the RTEMS build.